### PR TITLE
Attempt to fix flaky Linux Pythons.

### DIFF
--- a/expose-pythons/action.yml
+++ b/expose-pythons/action.yml
@@ -12,13 +12,23 @@ runs:
         fi
 
         echo "::group::Exposing Pythons"
-        for python_bin_dir in ${toolcache}/Python/*/x64/bin; do
+        for python_location in ${toolcache}/Python/*/x64; do
           # N.B.: Python 2.7 prints the version to stderr so we re-direct to get output all on one
           # line in that case.
+          python_bin_dir="${python_location}/bin"
           echo "Exposing ${python_bin_dir}: $(${python_bin_dir}/python --version 2>&1)"
           PATH="${PATH}:${python_bin_dir}"
+
+          python_lib_dir="${python_location}/lib"
+          LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${python_lib_dir}"
         done
         echo "::endgroup::"
 
         echo "PATH=${PATH}" >> $GITHUB_ENV
+
+        # The actions/setup-python@v2 action sets up LD_LIBRARY_PATH on Linux and so we do too to
+        # avoid issues like: https://github.com/pantsbuild/pex/issues/1391.
+        if [[ "$(uname -s)" == "Linux" ]]; then
+          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+        fi
       shell: bash


### PR DESCRIPTION
The actions/setup-python@v2 sets the LD_LIBRARY_PATH and so we do as
well.