### PR TITLE
Use ./pants bootstrap-cache-key for more reliable setup caching

### DIFF
--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -41,13 +41,16 @@ runs:
         PANTS_VERSION=$(grep -r '^pants_version\s*=' pants.toml)
         echo "::set-output name=pants_version::$PANTS_VERSION"
 
+        PYTHON_VERSION=$(which python)
+        echo "::set-output name=python_version::$PYTHON_VERSION"
+
     - name: Cache Pants Setup (${{ steps.pants_version.outputs.pants_version }}-py${{ inputs.pants-python-version }})
       id: cache-pants-setup
       uses: actions/cache@v2
       with:
         path: |
           ~/.cache/pants/setup
-        key: pants-setup-${{ runner.os }}-${{ steps.pants_version.outputs.pants_version }}-py${{ inputs.pants-python-version }}
+        key: pants-setup-${{ runner.os }}-${{ steps.pants_version.outputs.pants_version }}-py${{ steps.pants_version.outputs.python_version }}
 
     - name: Cache Pants Named Caches (${{ inputs.gha-cache-key }})
       uses: actions/cache@v2

--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -68,6 +68,7 @@ runs:
     # from the latest commit on the base branch.
     - name: Get Pants Cache Commit (base branch commit to pull cache from)
       id: pants-cache-commit
+      if: ${{ inputs.cache-lmdb-store == 'true' }}
       shell: bash
       # we could use this, but only if fetch-depth goes back far enough
       # COMMIT=$(git merge-base ${GITHUB_BASE_REF:-${{ inputs.base-branch }}} HEAD | head -n1)

--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -33,24 +33,25 @@ runs:
       with:
         python-version: '${{ inputs.pants-python-version }}'
 
-    - name: Get Pants version
+    - name: Get Pants bootstrap cache key
       id: pants_version
       shell: bash
       run: |
-        # Capture the "pants_version = " line from config.
-        PANTS_VERSION=$(grep -r '^pants_version\s*=' pants.toml)
-        echo "::set-output name=pants_version::$PANTS_VERSION"
+        if ! grep 'PANTS_BOOTSTRAP_TOOLS' ./pants; then
+            echo "This action requires a newer ./pants script. Please update following https://www.pantsbuild.org/docs/installation"
+            exit 1
+        fi
 
-        PYTHON_VERSION=$(which python)
-        echo "::set-output name=python_version::$PYTHON_VERSION"
+        PANTS_BOOTSTRAP_CACHE_KEY=$(PANTS_BOOTSTRAP_TOOLS=1 ./pants bootstrap-cache-key)
+        echo "::set-output name=pants_bootstrap_cache_key::$PANTS_BOOTSTRAP_CACHE_KEY"
 
-    - name: Cache Pants Setup (${{ steps.pants_version.outputs.pants_version }}-py${{ inputs.pants-python-version }})
+    - name: Cache Pants Setup
       id: cache-pants-setup
       uses: actions/cache@v2
       with:
         path: |
           ~/.cache/pants/setup
-        key: pants-setup-${{ runner.os }}-${{ steps.pants_version.outputs.pants_version }}-py${{ steps.pants_version.outputs.python_version }}
+        key: pants-setup-${{ steps.pants_version.outputs.pants_bootstrap_cache_key }}
 
     - name: Cache Pants Named Caches (${{ inputs.gha-cache-key }})
       uses: actions/cache@v2

--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -37,7 +37,7 @@ runs:
       id: pants_version
       shell: bash
       run: |
-        if ! grep 'PANTS_BOOTSTRAP_TOOLS' ./pants; then
+        if ! grep 'PANTS_BOOTSTRAP_TOOLS' ./pants > /dev/null; then
             echo "This action requires a newer ./pants script. Please update following https://www.pantsbuild.org/docs/installation"
             exit 1
         fi


### PR DESCRIPTION
The setup cache includes symlinks to things outside the cache, such as the (system) Python executable. Thus, the cache should only be reused on machines where those parts of the system exactly match up. This switches from trying to compute an appropriate cache key externally to letting the pants bootstrap script do it itself, via the new `PANTS_BOOTSTRAP_TOOLS=1 ./pants bootstrap-cache-key` (https://github.com/pantsbuild/setup/pull/128).

This is a breaking change, in that it requires updating the checked in pants scripts to support the new tool.

Fixes #5 