### PR TITLE
Migrate from `::set-output` to `$GITHUB_OUTPUT`.

### DIFF
--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -43,7 +43,7 @@ runs:
         fi
 
         PANTS_BOOTSTRAP_CACHE_KEY=$(PANTS_BOOTSTRAP_TOOLS=1 ./pants bootstrap-cache-key)
-        echo "::set-output name=pants_bootstrap_cache_key::$PANTS_BOOTSTRAP_CACHE_KEY"
+        echo "pants_bootstrap_cache_key=$PANTS_BOOTSTRAP_CACHE_KEY" >> $GITHUB_OUTPUT
 
     - name: Cache Pants Setup
       id: cache-pants-setup
@@ -78,7 +78,7 @@ runs:
           '/repos/${{ github.repository }}/commits?per_page=1&sha=${{ inputs.base-branch }}' \
           -q '.[].sha'
         )
-        echo "::set-output name=CACHECOMMIT::${CACHECOMMIT}"
+        echo "CACHECOMMIT=${CACHECOMMIT}" >> $GITHUB_OUTPUT
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/run-tox/action.yml
+++ b/run-tox/action.yml
@@ -10,6 +10,8 @@ runs:
     - name: Calculate Tox Version
       id: calculate-tox-version
       run: |
+        from __future__ import print_function
+
         try:
           from ConfigParser import ConfigParser
         except ImportError:
@@ -18,7 +20,8 @@ runs:
         cp = ConfigParser()
         cp.read("tox.ini")
         tox_min_version = cp.get("tox", "minversion")
-        print("::set-output name=tox-min-version::{}".format(tox_min_version))
+        with open(os.environ["GITHUB_OUTPUT"], "a") as gh_output_fp:
+          print("tox-min-version={}".format(tox_min_version), file=gh_output_fp)
       shell: python
     - name: Install Tox
       run: |


### PR DESCRIPTION
This gets ahead of the deprecation announced here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/