### PR TITLE
init-pants: Support new `get-pants.sh` that installs in `~/.local/bin` instead of `~/bin`

### DIFF
--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -87,7 +87,6 @@ runs:
       shell: bash
       run: |
         if ! command -v pants; then
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
           if [[ -f ./get-pants.sh ]]; then
             ./get-pants.sh
           else
@@ -95,6 +94,13 @@ runs:
               https://raw.githubusercontent.com/pantsbuild/setup/${{ inputs.setup-commit }}/get-pants.sh
             chmod +x ${{ runner.temp }}/get-pants.sh
             ${{ runner.temp }}/get-pants.sh
+          fi
+          # add 'pants' is on the PATH for subsequent actions.
+          if [[ -f "$HOME/bin/pants" ]]; then
+            # The repo might have a copy of an older get-pants.sh
+            echo "$HOME/bin" >> $GITHUB_PATH
+          else
+            echo "$HOME/.local/bin" >> $GITHUB_PATH
           fi
         fi
 

--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -16,7 +16,7 @@ inputs:
       Picking a specific commit is safer than downloading the current version.
     required: false
     # When we update get-pants.sh, we should update this commit.
-    default: baaf73b00d1f0c0508cfbdf4987dc9caa69d85b9
+    default: 6f136713a46e555946a22ffb3ed49c372eea58df
   base-branch:
     description: |
       The fallback commit to restore the local process cache from, if no cache
@@ -87,7 +87,7 @@ runs:
       shell: bash
       run: |
         if ! command -v pants; then
-          echo "$HOME/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
           if [[ -f ./get-pants.sh ]]; then
             ./get-pants.sh
           else


### PR DESCRIPTION
The newest version of `get-pants.sh` uses `~/.local/bin`: https://github.com/pantsbuild/setup/pull/144

This PR has backwards-compatible support for older in-repo copies of the script that still use `~/bin`, but it defaults to the newer `~/.local/bin`.