### PR TITLE
update GH cache action

### DIFF
--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -125,14 +125,14 @@ runs:
 
     - name: Cache Pants setup
       id: cache-pants-setup
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.pants_bootstrap_cache.outputs.pants_bootstrap_cache_dir }}
         key: pants-setup-${{ steps.pants_bootstrap_cache.outputs.pants_bootstrap_cache_key }}
 
     - name: Cache Pants named caches
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ inputs.named-caches-location }}
         key: pants-named-caches-${{ runner.os }}-${{ inputs.gha-cache-key }}-${{ hashFiles('pants.toml') }}-${{ inputs.named-caches-hash }}
@@ -163,7 +163,7 @@ runs:
 
     - name: Cache Pants LMDB store
       if: inputs.cache-lmdb-store == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-pants-lmdb-store
       with:
         path: ${{ inputs.lmdb-store-location }}

--- a/pyenv/action.yml
+++ b/pyenv/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Cache Pyenv
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/pyenv_root
         key: ${{ matrix.os }}-${{ runner.arch }}-install-pyenv-${{ inputs.pyenv-version }}-${{ inputs.python-version }}-v1


### PR DESCRIPTION
- v3 still uses node 16 which is deprecated
- see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- see https://github.com/actions/cache/releases/tag/v4.0.0