### PR TITLE
ci: Bump setup-python from v4 to v5

### DIFF
--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -106,7 +106,7 @@ runs:
 
     - name: Setup interpreter for testing in-repo Pants plugins
       if: inputs.setup-python-for-plugins == 'true'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
 


### PR DESCRIPTION
https://github.com/actions/setup-python/releases/tag/v5.0.0
setup-python@v4 is using the deprecated node16 version.
Upgrade to setup-python@v5 version using node20 version.