### PR TITLE
add init-pants action `input.experimental-remote-cache-via-gha`

### DIFF
--- a/init-pants/README.md
+++ b/init-pants/README.md
@@ -29,11 +29,6 @@ This action has no output.
 
 ### Required input arguments
 
-`gha-cache-key`: This is used to create the GHA cache keys for pants' `lmdb_store`
-and `named_caches`. When pulling the pants files from the GHA cache,
-this can be used to include relevant metadata (such as the python version your app is using),
-or to bust the cache, discarding old versions of the cached pants metadata.
-
 `named-caches-hash`: This is used to create the GHA cache key for pants' `named_caches`.
 Pants keeps pip and pex caches in the named caches, so they need to be invalidated
 when transitive dependencies change. The `named-caches-hash` should use the
@@ -43,18 +38,10 @@ resolving lockfiles. If you aren't using lockfiles, you can also hash
 `requirements.txt` and any `BUILD` files that define other dependencies.
 For example: `${{ hashFiles('lockfiles/*.json') }}`
 
-### Optional input arguments
-
-`pants-python-version`: Which version of python to install, specifically for pants. Defaults to `'3.9'`.
+### Optional input arguments (alphabetical order)
 
 `base-branch`: This action calculates the merge base for pull requests from this branch.
 Looking up the merge commit allows us to use the cache from the latest commit on the base branch.
-
-`pants-ci-config`: The value for the `PANTS_CONFIG_FILES` environment var.
-Set to empty to skip adding it to the environment for the rest of the workflow.
-Defaults to `pants.ci.toml`.
-For more about this var and the file naming convention, see:
-https://www.pantsbuild.org/docs/using-pants-in-ci#configuring-pants-for-ci-pantscitoml-optional
 
 `cache-lmdb-store`: Pass the string `'true'` to enable caching pants' lmdb store in
 a GHA cache. By default, this action does NOT cache the `lmdb_store`.
@@ -63,6 +50,34 @@ GitHub's 10GB per repo max for action caches. If you enable this, you need anoth
 process or workflow to manage discarding older GHA caches, or minimizing the cache size
 as described in the [docs](https://www.pantsbuild.org/docs/using-pants-in-ci).
 Use the default if using [remote caching](https://www.pantsbuild.org/docs/remote-caching).
+
+`experimental-remote-cache-via-gha`: This is used to configure the remote caching address
+and oauth token so that pants can use GHA as a fine-grained remote cache. You must also
+configure the other remote caching options in `pants.ci.toml` or similar as described in
+[remote caching](https://www.pantsbuild.org/2.20/docs/using-pants/remote-caching-and-execution/remote-caching#github-actions-cache).
+
+`gh-host`: This is used to add an enterprise GitHub host for API calls instead of `github.com`.
+
+`gha-cache-key`: This is used to create the GHA cache keys for pants' `lmdb_store`
+and `named_caches`. When pulling the pants files from the GHA cache,
+this can be used to include relevant metadata (such as the python version your app is using),
+or to bust the cache, discarding old versions of the cached pants metadata.
+
+`lmdb-store-location`: This is used to override the lmdb store cache location when the location
+has been customized in `pants.toml`.
+
+`named-caches-location`: This is used to override the named cache location when the location
+has been customized in `pants.toml`.
+
+`pants-ci-config`: The value for the `PANTS_CONFIG_FILES` environment var.
+Set to empty to skip adding it to the environment for the rest of the workflow.
+Defaults to `pants.ci.toml`.
+For more about this var and the file naming convention, see:
+https://www.pantsbuild.org/docs/using-pants-in-ci#configuring-pants-for-ci-pantscitoml-optional
+
+`setup-commit`: Which version/commit of get-pants.sh script to use when installing pants.
+
+`setup-python-for-plugins`: Ensure python is installed for linting/testing pants-plugins.
 
 ## Secrets
 

--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -60,6 +60,14 @@ inputs:
       Default is `~/.cache/pants/lmdb_store`.
     required: false
     default: "~/.cache/pants/lmdb_store"
+  experimental-remote-cache-via-gha:
+    description: |
+      Whether to add env variables that configure the Pants remote cache to use the GHA cache
+      (esp the [GLOBAL].remote_store_address, and [GLOBAL].remote_oauth_bearer_token options).
+      You must still configure the rest of the remote cache settings for these to take effect.
+      https://www.pantsbuild.org/2.20/docs/using-pants/remote-caching-and-execution/remote-caching#github-actions-cache
+    required: false
+    default: 'false' # a string!
   setup-python-for-plugins:
     description: |
       If set to 'true', this action will set up a Python interpreter suitable for testing/linting
@@ -173,6 +181,16 @@ runs:
         restore-keys: |
           pants-lmdb-store-${{ runner.os }}-${{ inputs.gha-cache-key }}-${{ steps.pants_cache_commit.outputs.CACHECOMMIT }}
           pants-lmdb-store-${{ runner.os }}-${{ inputs.gha-cache-key }}-
+
+    # These vars are required to use the experimental fine-grained remote caching via the GHA cache.
+    # https://www.pantsbuild.org/2.20/docs/using-pants/remote-caching-and-execution/remote-caching#workflow
+    - name: Configure Pants Remote Caching store
+      if: inputs.experimental-remote-cache-via-gha == 'true'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('PANTS_REMOTE_STORE_ADDRESS', process.env.ACTIONS_CACHE_URL);
+          core.exportVariable('PANTS_REMOTE_OAUTH_BEARER_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN);
 
     # Adding env vars to ${GITHUB_ENV} makes the vars show up for all subsequent steps
     # in the workflow that uses this composite action.


### PR DESCRIPTION
This makes the documented workflow step available via a simple boolean input flag:
https://www.pantsbuild.org/2.20/docs/using-pants/remote-caching-and-execution/remote-caching#workflow

Also, I noticed the README was out of date, so I updated it.