### PR TITLE
Added Dependabot and specified looking into sub-dirs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - expose-pythons
+      - init-pants
+      - pyenv
+      - run-tox
+    groups:
+      gha-deps:
+        patterns:
+          - "*"
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    assignees:
+      - sureshjoshi
     directories:
       - expose-pythons
       - init-pants
@@ -14,6 +16,3 @@ updates:
           - "*"
     schedule:
       interval: "monthly"
-    target-branch: "depbot"
-    assignees:
-      - sureshjoshi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,10 @@ updates:
     assignees:
       - sureshjoshi
     directories:
-      - expose-pythons
-      - init-pants
-      - pyenv
-      - run-tox
+      - "expose-pythons/*"
+      - "init-pants/*"
+      - "pyenv/*"
+      - "run-tox/*"
     groups:
       gha-deps:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
           - "*"
     schedule:
       interval: "monthly"
+    target-branch: "depbot"
+    assignees:
+      - sureshjoshi


### PR DESCRIPTION
Confirmed this worked in another repo, the "github-actions" workflow added better support for non-(.github/workflows) over the past few years.