### PR TITLE
init-pants: harden get-pants.sh download (retry + create-dirs)

### DIFF
--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -120,7 +120,9 @@ runs:
           if [[ -f ./get-pants.sh ]]; then
             ./get-pants.sh $VERSION_FLAG
           else
-            curl --proto '=https' --tlsv1.2 -fsSLo ${{ runner.temp }}/get-pants.sh \
+            curl --proto '=https' --tlsv1.2 \
+              --retry 3 --retry-delay 2 --retry-all-errors --create-dirs \
+              -fsSLo ${{ runner.temp }}/get-pants.sh \
               https://raw.githubusercontent.com/pantsbuild/setup/${{ inputs.setup-commit }}/get-pants.sh
             chmod +x ${{ runner.temp }}/get-pants.sh
             ${{ runner.temp }}/get-pants.sh $VERSION_FLAG


### PR DESCRIPTION
## Problem

The *Ensure the Pants launcher binary* step downloads `get-pants.sh` from `raw.githubusercontent.com` with a plain `curl -fsSLo` and **no retry**. A single transient response from the CDN therefore fails the step and aborts the whole workflow. We hit this in CI as:

```
Downloading and installing the pants launcher ...
curl: (22) The requested URL returned error: 504
##[error]Process completed with exit code 22.
```

Because the bootstrap runs once per job, any single job catching a transient 504 reds the entire run — re-running with no changes then passes, which is the classic signature of a missing retry.

## Change

Add resilience flags to that one `curl`:

- **`--retry 3 --retry-delay 2 --retry-all-errors`** — retry transient failures with backoff. `--retry` alone already covers HTTP 408/429/5xx (incl. 504) per the curl manpage, but depending on the negotiated HTTP version a CDN 5xx can surface either as a clean HTTP error (`curl: (22)`) or as a transport-level error (e.g. `curl: (56)`); `--retry-all-errors` covers both, which is appropriate for a one-shot bootstrap download where any failure aborts the run.
- **`--create-dirs`** — when `${{ runner.temp }}` (e.g. `/home/runner/work/_temp`) does not yet exist, the download fails with `curl: (23) Failure writing output to destination`. This is the maintainer-suggested fix in #22. **Closes #22.**

No behavior change on the success path; the flags only affect failure handling and output-path creation.